### PR TITLE
Update handlebars to 4.3.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -17,7 +17,7 @@
     "axios": "^0.19.0",
     "dotenv": "^8.1.0",
     "form-data": "^2.5.1",
-    "handlebars": "^4.2.0",
+    "handlebars": "^4.3.0",
     "jszip": "^3.2.2",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",


### PR DESCRIPTION
Addresses CVE-2019-19919  https://github.com/advisories/GHSA-w457-6q6x-cgp9